### PR TITLE
Corrected the spelling of Michael Stevens

### DIFF
--- a/src/quotes.kby
+++ b/src/quotes.kby
@@ -8,7 +8,7 @@
 substitute for life. ~ Robert Louis Stevenson in /An Apology for Idlers/
 
 > It's easy to think we know everything, but at the end of the day we are just a bunch of soft 
-animals walking in and out of rooms. ~ Micheal Stevens
+animals walking in and out of rooms. ~ Michael Stevens
 
 > What is life but a set of rooms, and what you become is the result of people you're 
 stuck with in those rooms. ~ Sandy Urazayev


### PR DESCRIPTION
Commit Title: Corrected the spelling of 'Michael Stevens' in quotes.kby

Commit Description:
In this commit, I have made a minor but significant change to the spelling of the name 'Michael Stevens' in the `quotes.kby` file. Previously, it was incorrectly spelled as 'Micheal Stevens'. This error could have led to confusion and miscommunication, as 'Michael' and 'Micheal' could potentially refer to two different individuals.

The change was made in line 11 of the `quotes.kby` file, where 'Michael Stevens' is quoted. This quote is part of a collection of quotes that are meant to inspire and motivate. Therefore, it is of utmost importance that all names are spelled correctly to properly attribute the quote to its author.

The incorrect spelling 'Micheal' was replaced with the correct spelling 'Michael'. This change ensures that 'Michael Stevens' is correctly recognized and acknowledged for his insightful quote.

This commit serves as a reminder of the importance of attention to detail in all aspects of code development, even in areas that may seem trivial such as the spelling of names.

This change does not affect the functionality of the code and does not require any additional changes or updates.